### PR TITLE
feat(docker): add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM rust:1.40-stretch as builder
+RUN rustup target add x86_64-unknown-linux-musl
+RUN cargo install microserver --version 0.1.6 --target=x86_64-unknown-linux-musl
+# Add tini here because chmod doesn't
+# exist in the final container
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+
+FROM gcr.io/distroless/base:nonroot@sha256:2b177fbc9a31b85254d264e1fc9a65accc6636d6f1033631b9b086ee589d1fe2
+COPY --from=builder /usr/local/cargo/bin/microserver /microserver
+COPY --from=builder /tini /tini
+EXPOSE 9090
+ENTRYPOINT ["/tini", "--"]
+CMD ["/microserver", "/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
-FROM rust:1.40-stretch as builder
-RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo install microserver --version 0.1.6 --target=x86_64-unknown-linux-musl
-# Add tini here because chmod doesn't
-# exist in the final container
+FROM ekidd/rust-musl-builder AS builder
+# Add our source code.
+ADD . ./
+# build for musl
+RUN cargo build --release
+# Add tini here because chmod doesn't exist in the final container
 ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN sudo chown -R rust:rust /tini
 RUN chmod +x /tini
 
 
 FROM gcr.io/distroless/base:nonroot@sha256:2b177fbc9a31b85254d264e1fc9a65accc6636d6f1033631b9b086ee589d1fe2
-COPY --from=builder /usr/local/cargo/bin/microserver /microserver
+COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/microserver /
 COPY --from=builder /tini /tini
 EXPOSE 9090
 ENTRYPOINT ["/tini", "--"]

--- a/README.md
+++ b/README.md
@@ -49,3 +49,54 @@ SPA support is enabled by default, meaning that if a resource is not found traff
 If you want to opt-out of this behavior just use the `--no-spa` flag.
 
 In the case you ever need to change the default `spa index` you can provide the `--spa-index` flag.
+
+## Docker
+
+There are several ways to use `microserver` with a [Docker image](https://hub.docker.com/repository/docker/robertohuertasm/microserver/):
+
+With a **Dockerfile** like the following:
+
+```dockerfile
+# please omit the version if you just want the latest
+FROM robertohuertasm/microserver:v0.1.6
+# public being the location of your app files
+COPY public/ /app/
+```
+
+You can also run your SPA / static site using:
+
+```bash
+$ docker build -t my-service:local .
+$ docker run -p 9090:9090 my-service:local
+MicroServer running on port 9090!
+Serving /app
+Spa support: true. Root: index.html
+```
+
+Alternatively, you could mount a volume with your content:
+
+```bash
+docker run -p 9090:9090 -v $(pwd)/public:/app robertohuertasm/microserver:v0.1.6
+```
+
+More complex Dockerfile usage example with a multi-stage build of a React SPA:
+
+```dockerfile
+FROM node:10.18-stretch-slim as builder
+WORKDIR /app
+COPY ./ /app
+RUN yarn
+RUN yarn build
+
+FROM robertohuertasm/microserver:v0.1.6
+COPY --from=builder /app/public /app/
+```
+
+### If you don't want the default arguments
+
+In this case whenever you run the `microserver` image, you'll have to be explicit about the arguments:
+
+```bash
+# don't forget to add "/app" as your final argument
+docker run -p 9090:9090 -v $(pwd)/public:/app robertohuertasm/microserver:v0.1.6 "/microserver" "--no-spa" "/app"
+```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ FROM robertohuertasm/microserver:v0.1.6
 COPY public/ /app/
 ```
 
-You can also run your SPA / static site using:
+You can then run your SPA / static site using:
 
 ```bash
 $ docker build -t my-service:local .

--- a/index.html
+++ b/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>Document</title>
 </head>
+
 <body>
-Hello from MicroServer!
+    Hello from MicroServer!
 </body>
+
 </html>


### PR DESCRIPTION
Thanks for this project! It's exactly what I was hoping to find for really simple static sites and single page apps!

---

This PR adds a Dockerfile that can be used to deploy SPAs or static sites to Docker / Kubernetes. Expects SPA / static site content to be included in the `/app/` directory.

Notes:
 - Statically builds microserver with musl as the resulting binary is more portable
 - Uses [Distroless](https://github.com/GoogleContainerTools/distroless) to keep the base image small (~20MB total)
 - Uses [tini](https://github.com/krallin/tini) to ensure that the container shuts down quickly and cleanly (proper signal handling) in Kubernetes
 - Uses non-root user in the container for the sake of security

### Intended Usage
With a Dockerfile like the following:
```dockerfile
FROM nessex/microserver:release-v0.1.6
COPY public/ /app/
```

You can run your SPA / static site using:
```bash
$ docker build -t my-service:local .
$ docker run -p 9090:9090 my-service:local
MicroServer running on port 9090!
Serving /app
Spa support: true. Root: index.html
```

Alternatively, you could mount a volume with your content:
```
$ docker run -p 9090:9090 -v $(pwd)/public:/app nessex/microserver:release-v0.1.6
```

More complex Dockerfile usage example with a multi-stage build of a React SPA:
```
FROM node:10.18-stretch-slim as builder
WORKDIR /app
COPY ./ /app
RUN yarn
RUN yarn build


FROM nessex/microserver:release-v0.1.6
COPY --from=builder /app/public /app/
```

### Extra Steps Required
This would work best with an automated build configured through Docker hub. https://hub.docker.com

To test this Dockerfile, I created a repository at https://hub.docker.com/r/nessex/microserver with the following automated build config (to match your existing release tags):

![Screen Shot 2020-01-22 at 17 36 21](https://user-images.githubusercontent.com/1081140/72878133-bcea6a00-3d3d-11ea-8ba6-40b1b714114f.png)

If you are interested in this PR, and want to create a repository e.g. `robertohuertasm/microserver`, I can add some instructions to `README.md` for using the built images.